### PR TITLE
chore(release): 1.0.0-development.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "timer-worker",
-  "version": "0.0.1",
+  "version": "1.0.0-development.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "timer-worker",
-      "version": "0.0.1",
+      "version": "1.0.0-development.1",
       "license": "MIT",
       "dependencies": {
         "@koa/router": "12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timer-worker",
-  "version": "0.0.1",
+  "version": "1.0.0-development.1",
   "description": "stand alone application to execute timer nodes",
   "main": "src/server.ts",
   "scripts": {


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.0.0-development.1](https://github.com/flow-build/timer-worker/releases/tag/v1.0.0-development.1)