### PR TITLE
chore(release): 1.0.0-development.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "timer-worker",
-  "version": "1.0.0-development.1",
+  "version": "1.0.0-development.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "timer-worker",
-      "version": "1.0.0-development.1",
+      "version": "1.0.0-development.2",
       "license": "MIT",
       "dependencies": {
         "@koa/router": "12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timer-worker",
-  "version": "1.0.0-development.1",
+  "version": "1.0.0-development.2",
   "description": "stand alone application to execute timer nodes",
   "main": "src/server.ts",
   "scripts": {


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.0.0-development.2](https://github.com/flow-build/timer-worker/releases/tag/v1.0.0-development.2)